### PR TITLE
Move setup to YAML

### DIFF
--- a/engines.yaml
+++ b/engines.yaml
@@ -1,0 +1,11 @@
+justjoin:
+  id: justjoin
+  template: https://justjoin.it/job-offers/all-locations?keyword=$input_text&from=0
+
+inhire:
+  id: inhire *
+  template: https://inhire.io/?roles=big_data
+
+solid jobs:
+  id: solid jobs
+  template: https://solid.jobs/offers/it;searchTerm=$input_text

--- a/engines.yaml
+++ b/engines.yaml
@@ -9,3 +9,7 @@ inhire:
 solid jobs:
   id: solid jobs
   template: https://solid.jobs/offers/it;searchTerm=$input_text
+
+jobble:
+  id: jobble
+  template: https://pl.jooble.org/SearchResult?rgns=Gda%C5%84sk&ukw=$input_text

--- a/search_engine_comparison.py
+++ b/search_engine_comparison.py
@@ -38,7 +38,7 @@ def get_engines() -> dict:
     Returns:
         dict: id and template are mandatory
     """
-    with open("engines.yaml", "r", encoding="utf-8") as file:
+    with open("engines.yaml", "r") as file:
         engines = yaml.safe_load(file)
 
     for engine in engines.values():

--- a/search_engine_comparison.py
+++ b/search_engine_comparison.py
@@ -4,6 +4,7 @@ v0.1 - basic version
 """
 
 from string import Template
+import yaml
 
 import streamlit as st
 import streamlit.components.v1 as components
@@ -37,50 +38,13 @@ def get_engines() -> dict:
     Returns:
         dict: id and template are mandatory
     """
-    # pylint: disable=C0301
+    with open("engines.yaml", "r") as file:
+        engines = yaml.safe_load(file)
 
-    return {
-        "justjoin": {
-            "id": "justjoin",
-            "template": Template(
-                "https://justjoin.it/job-offers/all-locations?keyword=$input_text&from=0"
-            ),
-        },
-        "inhire": {
-            "id": "inhire *",
-            "template": Template("https://inhire.io/?roles=big_data"),
-        },
-        "solid jobs": {
-            "id": "solid jobs",
-            "template": Template("https://solid.jobs/offers/it;searchTerm=$input_text"),
-        },
-        "indeed": {
-            "id": "indeed",
-            "template": Template("https://pl.indeed.com/jobs?q=$input_text"),
-        },
-        "theprotocol": {
-            "id": "theprotocol",
-            "template": Template(
-                "https://theprotocol.it/filtry/gdansk;wp?kw=$input_text"
-            ),
-        },
-        "rocketjobs": {
-            "id": "rocketjobs",
-            "template": Template(
-                "https://rocketjobs.pl/oferty-pracy/wszystkie-lokalizacje?keyword=$input_text&from=0"
-            ),
-        },
-        "pracuj": {
-            "id": "pracuj",
-            "template": Template("https://www.pracuj.pl/praca/$input_text"),
-        },
-        "nofluffjobs": {
-            "id": "nofluffjobs",
-            "template": Template("https://nofluffjobs.com/pl//$input_text"),
-        },
-        # // add more here
-        # https://snaphunt.com/resources/sourcing-and-assessing-talent/top-job-posting-sites-in-poland
-    }
+    for engine in engines.values():
+        engine["template"] = Template(engine["template"])
+
+    return engines
 
 
 def get_container(input_text: str, jl_id: str, template: Template):

--- a/search_engine_comparison.py
+++ b/search_engine_comparison.py
@@ -38,7 +38,7 @@ def get_engines() -> dict:
     Returns:
         dict: id and template are mandatory
     """
-    with open("engines.yaml", "r") as file:
+    with open("engines.yaml", "r", encoding="utf-8") as file:
         engines = yaml.safe_load(file)
 
     for engine in engines.values():


### PR DESCRIPTION
Fixes #3

Move setup for 'justjoin', 'inhire', and 'solid jobs' to YAML format.

* Add `engines.yaml` file with setup for 'justjoin', 'inhire', and 'solid jobs'.
* Import `yaml` module in `search_engine_comparison.py`.
* Update `get_engines` function to read setup from `engines.yaml`.
* Remove hardcoded dictionary from `get_engines` function.
* Convert templates in `engines.yaml` to `Template` objects in `get_engines` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/obar1/onepage_job_lister/pull/4?shareId=8b97e0a9-8516-4459-afc5-c585be86595d).